### PR TITLE
Fix charge_rate when discharging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - MSRV was raised to 1.62.0.
 
+### Fixed
+
+- MAX17048 & MAX17049 `charge_rate` correctly handles negative values (such as when discharging). See: [PR #2](https://github.com/eldruin/max170xx-rs/pull/2)
+
 ## 0.1.0 - 2020-07-19
 
 Initial release of the driver to crates.io.

--- a/src/max170x8_x9.rs
+++ b/src/max170x8_x9.rs
@@ -100,7 +100,7 @@ macro_rules! impl_common_48_49 {
             /// Get the approximate charge or discharge rate of the battery
             /// in percentage / hour
             pub fn charge_rate(&mut self) -> Result<f32, Error<E>> {
-                let rate = self.read_register(Register::CRATE)?;
+                let rate = self.read_register(Register::CRATE)? as i16;
                 Ok(f32::from(rate) * 0.208)
             }
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -127,6 +127,16 @@ mod max17048 {
     get_float!(get_soc, new_48, destroy_48, soc, SOC, 48, 126, 48.49);
     get_float!(voltage, new_48, destroy_48, voltage, VCELL, 0xA4, 0x9F, 3.29);
     get_float!(rate, new_48, destroy_48, charge_rate, CRATE, 1, 0x45, 67.6);
+    get_float!(
+        negative_rate,
+        new_48,
+        destroy_48,
+        charge_rate,
+        CRATE,
+        0xFE,
+        0xBB,
+        -67.6
+    );
     cmd_test!(reset, new_48, destroy_48, reset, COMMAND, POR_X8_X9);
     set_table_test!(set_table, new_48, destroy_48);
 }
@@ -144,6 +154,16 @@ mod max17049 {
     get_float!(get_soc, new_49, destroy_49, soc, SOC, 48, 126, 48.49);
     get_float!(voltage, new_49, destroy_49, voltage, VCELL, 0xA4, 0x9F, 6.58);
     get_float!(rate, new_49, destroy_49, charge_rate, CRATE, 1, 0x45, 67.6);
+    get_float!(
+        negative_rate,
+        new_49,
+        destroy_49,
+        charge_rate,
+        CRATE,
+        0xFE,
+        0xBB,
+        -67.6
+    );
     cmd_test!(reset, new_49, destroy_49, reset, COMMAND, POR_X8_X9);
     set_table_test!(set_table, new_49, destroy_49);
 }


### PR DESCRIPTION
As reported in #1, MAX17048 & MAX17049 yield negative `CRATE` values when discharging, so interpret them as i16 instead of u16 before converting to f32.

(I’m relatively new to Rust so feel free to point me towards a different idiom to use here if you’d prefer)

Fixes #1 