### PR TITLE
Ported the Max170xx-rs crate to use Hal 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ...
 
+## 0.1.2 - 2024-4-18
+- Embedded-hal was raised to 1.0.0
+- linux-embedded-hal raised to 0.4 for embedded-hal 1.0.0 support
+- embedded-hal-mock specify embedded-hal 1.0.0 feature set
+
 ## 0.1.1 - 2023-12-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ include = [
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.9"
+embedded-hal-mock = "0.10.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ edition = "2021"
 embedded-hal = "1.0.0"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.10.0"
+linux-embedded-hal = "0.4"
+embedded-hal-mock = {version="0.10.0", features=['eh1']}
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ embedded-hal = "1.0.0"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
-embedded-hal-mock = {version="0.10.0", features=['eh1']}
+embedded-hal-mock = {version="0.10.0", default-features=false, features=['eh1']}
 
 [profile.release]
 lto = true

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ macro_rules! impl_common {
 
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Create new instance of the device.
             pub fn new(i2c: I2C) -> Self {

--- a/src/max17043_44.rs
+++ b/src/max17043_44.rs
@@ -29,7 +29,7 @@ impl_common_4x!(Max17044);
 
 impl<I2C, E> Max17043<I2C>
 where
-I2C: i2c::I2c<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Get battery voltage
     pub fn voltage(&mut self) -> Result<f32, Error<E>> {
@@ -40,7 +40,7 @@ I2C: i2c::I2c<Error = E>,
 
 impl<I2C, E> Max17044<I2C>
 where
-I2C: i2c::I2c<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Get battery voltage
     pub fn voltage(&mut self) -> Result<f32, Error<E>> {

--- a/src/max17043_44.rs
+++ b/src/max17043_44.rs
@@ -1,5 +1,5 @@
 use crate::{Command, Error, Register, ADDR};
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl_common!(Max17043);
 impl_common!(Max17044);
@@ -8,7 +8,7 @@ macro_rules! impl_common_4x {
     ($ic:ident) => {
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Get state of charge of the cell as calculated by the ModelGauge
             /// algorithm as a percentage.
@@ -29,7 +29,7 @@ impl_common_4x!(Max17044);
 
 impl<I2C, E> Max17043<I2C>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+I2C: i2c::I2c<Error = E>,
 {
     /// Get battery voltage
     pub fn voltage(&mut self) -> Result<f32, Error<E>> {
@@ -40,7 +40,7 @@ where
 
 impl<I2C, E> Max17044<I2C>
 where
-    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+I2C: i2c::I2c<Error = E>,
 {
     /// Get battery voltage
     pub fn voltage(&mut self) -> Result<f32, Error<E>> {

--- a/src/max170x8_x9.rs
+++ b/src/max170x8_x9.rs
@@ -1,5 +1,5 @@
 use crate::{Command, Error, Register, ADDR};
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl_common!(Max17048);
 impl_common!(Max17049);
@@ -10,7 +10,7 @@ macro_rules! impl_common_x8_x9 {
     ($ic:ident) => {
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Get state of charge of the cell as calculated by the ModelGauge
             /// algorithm as a percentage.
@@ -26,7 +26,7 @@ macro_rules! impl_common_x8_x9 {
         }
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Set table values.
             ///
@@ -61,7 +61,7 @@ macro_rules! impl_common_x8 {
     ($ic:ident) => {
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Get battery voltage in Volts
             pub fn voltage(&mut self) -> Result<f32, Error<E>> {
@@ -78,7 +78,7 @@ macro_rules! impl_common_x9 {
     ($ic:ident) => {
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Get battery voltage in Volts
             pub fn voltage(&mut self) -> Result<f32, Error<E>> {
@@ -95,7 +95,7 @@ macro_rules! impl_common_48_49 {
     ($ic:ident) => {
         impl<I2C, E> $ic<I2C>
         where
-            I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             /// Get the approximate charge or discharge rate of the battery
             /// in percentage / hour

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -21,7 +21,7 @@ macro_rules! impl_register_access {
     ($name:ident) => {
         impl<I2C, E> $name<I2C>
         where
-            I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+            I2C: i2c::I2c<Error = E>,
         {
             pub(crate) fn write_register(
                 &mut self,

--- a/tests/base/mod.rs
+++ b/tests/base/mod.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use max170xx::{Max17043, Max17044, Max17048, Max17049, Max17058, Max17059};
 
 pub const ADDR: u8 = 0b011_0110;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,7 @@ use crate::base::{
     destroy_43, destroy_44, destroy_48, destroy_49, destroy_58, destroy_59, new_43, new_44, new_48,
     new_49, new_58, new_59, Command, Register, ADDR,
 };
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 macro_rules! get_float {
     ($name:ident, $create:ident, $destroy:ident, $method:ident, $reg:ident, $v0:expr, $v1:expr, $expected:expr) => {


### PR DESCRIPTION
I updated all the trait definitions and tests in order for the driver to be compatible with Hal 1.0. 

I understand that this would break compatibility with Hal-0.2.x. I'm creating the pull request to see how this should move forward, and how the versioning differences should be handled. 